### PR TITLE
Dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*/version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel", "sphinx"]
+requires = ["setuptools", "wheel", "sphinx", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "RVdata"
-version = "0.0.2"
+dynamic = ["version"]
 description = "EPRV Data Standardization Project"
 authors = [
     { name="BJ Fulton", email="bjfulton@ipac.caltech.edu" }
@@ -53,6 +53,9 @@ include-package-data = true
 [tool.setuptools.packages]
 find = {}
 
+[tool.setuptools_scm]
+version_file = "rvdata/version.py"
+
 [tool.poe.tasks]
 # Task automation using poe the poet (Optional)
 docs = "sphinx-build -b html docs/source docs/_build/html"
@@ -73,6 +76,7 @@ addopts = [
         omit = [
             "rvdata/core/models/config/*",
             "rvdata/tests/*",
+            "rvdata/version.py",
         ]
 
     [tool.coverage.report]

--- a/rvdata/core/__init__.py
+++ b/rvdata/core/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from .version import version as __version__
+except ImportError:
+    __version__ = ""


### PR DESCRIPTION
This PR configures the `setuptools_scm` magic that enables dynamic versioning via git tags and commit hashes. This is most useful for development where installing from a specific point in the commit history will generate a unique version identifier. It will also help prevent git tags and hard-coded versions from getting out of sync. The versions defined in git will be the ground truth.