### PR TITLE
Initial benchmarking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
           python -m pip install tox
       - name: Run benchmark tests with tox
         run: |
-          tox -e py3${{ matrix.python-ver }}-${{ matrix.tox-env }} -- --benchmark-json output.json
+          tox -e py3${{ matrix.python-ver }}-${{ matrix.tox-env }} -- --benchmark-json ${{ runner.temp }}/output.json
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'pytest'
-          output-file-path: output.json
+          output-file-path: ${{ runner.temp }}/output.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         matrix:
           os: [ubuntu-latest]
           python-ver: [12, 13]
-          tox-env: [test, test-oldestdeps, test-devdeps, benchmark]
+          tox-env: [test, test-oldestdeps, test-devdeps]
       steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.${{ matrix.python-ver }} with tox environment ${{ matrix.tox-env }} on ${{ matrix.os }}
@@ -41,6 +41,32 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox
-      - name: Run tests with tox
+      - name: Run regression tests with tox
         run: |
           tox -e py3${{ matrix.python-ver }}-${{ matrix.tox-env }}
+
+    benchmark:
+      runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          os: [ubuntu-latest]
+          python-ver: [13]
+          tox-env: [benchmark, benchmark-devdeps]
+      steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.${{ matrix.python-ver }} with tox environment ${{ matrix.tox-env }} on ${{ matrix.os }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.${{ matrix.python-ver }}'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Run benchmark tests with tox
+        run: |
+          tox -e py3${{ matrix.python-ver }}-${{ matrix.tox-env }} -- --benchmark-json output.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: output.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         matrix:
           os: [ubuntu-latest]
           python-ver: [12, 13]
-          tox-env: [test, test-oldestdeps, test-devdeps]
+          tox-env: [test, test-oldestdeps, test-devdeps, benchmark]
       steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.${{ matrix.python-ver }} with tox environment ${{ matrix.tox-env }} on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,7 @@ jobs:
           python -m pip install tox
       - name: Run benchmark tests with tox
         run: |
+          # we're using a temporary file to store the benchmark results, but can't do anything with it until
+          # we set up gh-pages to store and display the results.
           tox -e py3${{ matrix.python-ver }}-${{ matrix.tox-env }} -- --benchmark-json ${{ runner.temp }}/output.json
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'pytest'
-          output-file-path: ${{ runner.temp }}/output.json
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name="BJ Fulton", email="bjfulton@ipac.caltech.edu" }
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 
 dependencies = [
     "astropy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ dependencies = [
     "pandas",
     "GitPython",
     "specutils",
-    "sphinx",
-    "sphinx-rtd-theme",  # ReadTheDocs theme for Sphinx
-    "sphinxcontrib-napoleon"
 ]
 
 # Optional dependencies
@@ -30,9 +27,12 @@ dev = [
     "flake8",      # Code linting
     "pytest",      # Testing
     "tox",         # Testing
-    "sphinx",      # Documentation
+    "pytest-benchmark", # Benchmarking
+    "coverage",    # Code coverage
+    "sphinx",            # Documentation
+    "sphinx-rtd-theme",  # ReadTheDocs theme for Sphinx
+    "sphinxcontrib-napoleon",
     "sphinx-autodoc-typehints",
-    "sphinx-rtd-theme",
 ]
 
 [tool.black]

--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -228,7 +228,7 @@ class RVDataModel(object):
             git_commit_hash = repo.head.object.hexsha
             git_branch = repo.active_branch.name
             git_tag = str(repo.tags[-1])
-        except TypeError:  # expected if running in testing env
+        except (TypeError, IndexError):  # expected if running in testing env
             git_commit_hash = ""
             git_branch = ""
             git_tag = ""

--- a/rvdata/tests/regression/test_kpf.py
+++ b/rvdata/tests/regression/test_kpf.py
@@ -37,5 +37,12 @@ def test_kpf():
     # check_l2_header(l2_standard.headers['PRIMARY'])
 
 
+def test_kpf_benchmark(benchmark):
+    # run test_kpf() once to download the files
+    test_kpf()
+    # now run it again with benchmark
+    benchmark(test_kpf)
+
+
 if __name__ == "__main__":
     test_kpf()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{312,313}-test{,-oldestdeps,-devdeps,-predeps}{,-cov}
+    py{312,313}-test{,-oldestdeps,-devdeps,-predeps,-benchmark}{,-cov}
     codestyle
 
 [testenv]
@@ -41,7 +41,7 @@ deps =
     oldestdeps: astropy==7.0.*
     oldestdeps: specutils==1.9.*
 
-# The following indicates which extras_require from setup.cfg will be installed
+# The following indicates which optional dependencies from pyproject.toml will be installed
 extras =
     dev
 
@@ -52,8 +52,9 @@ install_command =
 
 commands =
     pip freeze
-    !cov: pytest --pyargs rvdata {posargs}
-    cov: pytest --pyargs rvdata --cov rvdata --cov-config={toxinidir}/pyproject.toml {posargs}
+    benchmark: pytest --benchmark-only --pyargs rvdata {posargs}
+    test: pytest --benchmark-skip --pyargs rvdata {posargs}
+    cov: pytest --benchmark-skip --pyargs rvdata --cov rvdata --cov-config={toxinidir}/pyproject.toml {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 pip_pre =


### PR DESCRIPTION
This PR adds support for `pytest-benchmark`. It configures `tox` to skip benchmarks if the environment name includes `test` and run benchmarks while skipping tests if it includes `benchmark`. An initial benchmark of `test_kpf()` is included and a `benchmark` run is added to the CI matrix.